### PR TITLE
fix(python): correctly handle type casts

### DIFF
--- a/src/templates/routes.py.ejs
+++ b/src/templates/routes.py.ejs
@@ -24,7 +24,7 @@ function generate_method_name(method, path) {
 // "INSERT INTO ... VALUES(:categoryId)" => "INSERT INTO ... VALUES(%(categoryId)s)"
 // See: https://www.psycopg.org/docs/usage.html#passing-parameters-to-sql-queries
 function convertToPsycopgNamedArguments(sql) {
-    return sql.replace(/:([_a-zA-Z]+)/g, '%($1)s')
+    return sql.replace(/(?<!:):([_a-zA-Z]+)/g, '%($1)s')
 }
 
 // "/categories/:categoryId" => "/categories/{categoryId}"


### PR DESCRIPTION
Сейчас утилита работает неправильно с тайпкастами:
::timestamp -> :%(timestamp)s
ПР исправляет этот баг.

Fixes #20 